### PR TITLE
moved generateMarkdown.js to a new subfolder

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const inquirer = require('inquirer');
 
 // Import generateMarkdown to create markdown content
-const generateMarkdown = require("./generateMarkdown");
+const generateMarkdown = require("./markdown/generateMarkdown");
 
 // Function to initialize the application
 function init() {
@@ -64,7 +64,7 @@ function init() {
         // Generate markdown content based on user answers
         const potentialFile = generateMarkdown(answers);
         // Write the generated markdown content to a file named 'README.md and place it in the results folder'
-        fs.writeFile('./results/README.md' , potentialFile, (err) => {
+        fs.writeFile('./markdown/README.md' , potentialFile, (err) => {
             // Log any errors that occur during file writing
             console.log(err);
         })

--- a/markdown/generateMarkdown.js
+++ b/markdown/generateMarkdown.js
@@ -9,7 +9,6 @@ function generateMarkdown(data) {
       
     return `# ${data.title}
 
-// Create a badge and ensure correct rendering when there are spaces
 ![License: ${data.license}](https://img.shields.io/badge/License-${encodeURIComponent(data.license)}-blue)
 
 ## Description


### PR DESCRIPTION
PR to move generateMarkdown.js to a new subfolder.

Previously, the newly created README would be placed into a results folder. This folder would not upload to GitHub as it was empty by default. generateMarkdown.js has been moved into a markdown folder which is also the output for the README.md.

Also removed a line of commented code as it was inside the backtick and being printed to the README.md.